### PR TITLE
Add prettier as eplicit dev-dependency

### DIFF
--- a/examples/elements/package.json
+++ b/examples/elements/package.json
@@ -55,6 +55,7 @@
     "eslint-config-jam": "^0.1.6",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.12.4",
+    "prettier": "^2.0.5",
     "yo": "^2.0.5"
   },
   "engines": {


### PR DESCRIPTION
This demo doesn't run without prettier, so I guess it's OK to add it in here.